### PR TITLE
fix: A PackageReference to the package 'NuGet.Frameworks' at version …

### DIFF
--- a/docs/UpdatR.SampleApp/UpdatR.SampleApp.csproj
+++ b/docs/UpdatR.SampleApp/UpdatR.SampleApp.csproj
@@ -7,6 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!--
+      Needed directly: UpdatR.csproj marks its own Microsoft.Build.Locator PackageReference
+      PrivateAssets="all" (see the comment there), which also stops it flowing transitively via
+      the ProjectReference below. This project consumes UpdatR via ProjectReference, not the
+      packed .nupkg, so it must reference the same version itself to get
+      Microsoft.Build.Locator.dll copied to its own output - UpdatR.dll's ModuleInitializer
+      requires it to be physically present at runtime.
+    -->
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\UpdatR\UpdatR.csproj" />
   </ItemGroup>
 </Project>

--- a/src/UpdatR/ModuleInitializer.cs
+++ b/src/UpdatR/ModuleInitializer.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
 
 namespace UpdatR;
 
@@ -40,6 +42,21 @@ internal static class ModuleInitializer
     [ModuleInitializer]
     internal static void Initialize()
     {
+        // UpdatR.MsBuild.dll and Microsoft.Build.Locator.dll are bundled directly into UpdatR's own
+        // package output instead of being declared as regular NuGet dependencies (see the
+        // PrivateAssets="all" comments in UpdatR.csproj - a real dependency would break every
+        // consumer's build via Microsoft.Build.Locator's MSBL001 buildTransitive check). That means
+        // neither assembly is guaranteed to be listed in a consuming app's .deps.json, which the
+        // default AssemblyLoadContext uses to build its trusted-assembly list for
+        // framework-dependent apps. Relying on that default, implicit probing to still find the
+        // files is fragile: they ARE physically copied next to UpdatR.dll (NuGet copies every file
+        // under a referenced package's lib/<tfm> folder to the consumer's output directory
+        // regardless of .deps.json), but resolving a simple assembly name still failed with a
+        // FileNotFoundException on Linux even though the exact same package/output layout worked
+        // fine on Windows. Resolving both assemblies explicitly from UpdatR.dll's own directory
+        // removes any dependency on .deps.json - or on any OS-specific probing behavior - entirely.
+        AssemblyLoadContext.Default.Resolving += ResolveBundledDependency;
+
         try
         {
             UpdatR.MsBuild.MsBuildProjectInspector.EnsureMsBuildLocatorIsRegistered();
@@ -62,5 +79,27 @@ internal static class ModuleInitializer
                 ex
             );
         }
+    }
+
+    private static Assembly? ResolveBundledDependency(
+        AssemblyLoadContext context,
+        AssemblyName assemblyName
+    )
+    {
+        if (assemblyName.Name is not ("UpdatR.MsBuild" or "Microsoft.Build.Locator"))
+        {
+            return null;
+        }
+
+        var updatrDirectory = Path.GetDirectoryName(typeof(ModuleInitializer).Assembly.Location);
+
+        if (string.IsNullOrEmpty(updatrDirectory))
+        {
+            return null;
+        }
+
+        var candidatePath = Path.Combine(updatrDirectory, assemblyName.Name + ".dll");
+
+        return File.Exists(candidatePath) ? context.LoadFromAssemblyPath(candidatePath) : null;
     }
 }

--- a/src/UpdatR/ModuleInitializer.cs
+++ b/src/UpdatR/ModuleInitializer.cs
@@ -55,8 +55,24 @@ internal static class ModuleInitializer
         // FileNotFoundException on Linux even though the exact same package/output layout worked
         // fine on Windows. Resolving both assemblies explicitly from UpdatR.dll's own directory
         // removes any dependency on .deps.json - or on any OS-specific probing behavior - entirely.
+        //
+        // This registration MUST happen in a method that itself contains no reference to any
+        // UpdatR.MsBuild type: the JIT resolves every type referenced by a method's IL - including
+        // simple call targets - while compiling THAT method, before any of its instructions
+        // actually run. If the Resolving registration and the call into UpdatR.MsBuild lived in the
+        // same method, compiling this method would try to resolve UpdatR.MsBuild before the
+        // registration line ever executed, so the handler would never get a chance to run (this
+        // was tried and confirmed not to fix the issue). Splitting the actual usage into a separate
+        // NoInlining method defers resolving UpdatR.MsBuild until that method is actually invoked,
+        // by which point the handler below is already registered.
         AssemblyLoadContext.Default.Resolving += ResolveBundledDependency;
 
+        RegisterMsBuildLocator();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void RegisterMsBuildLocator()
+    {
         try
         {
             UpdatR.MsBuild.MsBuildProjectInspector.EnsureMsBuildLocatorIsRegistered();

--- a/src/UpdatR/UpdatR.csproj
+++ b/src/UpdatR/UpdatR.csproj
@@ -42,10 +42,10 @@
       <dependency id="UpdatR.MsBuild" .../> in UpdatR's nuspec (NuGet's default behavior for any
       ProjectReference). That dependency could never be resolved by consumers since no such package
       exists, breaking every restore of the UpdatR package. PrivateAssets="all" also suppresses
-      Microsoft.Build.Locator (a real, published dependency of UpdatR.MsBuild) from flowing to
-      UpdatR's nuspec, so the CopyProjectReferencesToPackage target below both bundles
-      UpdatR.MsBuild.dll's compiled output directly into UpdatR's own package and re-adds
-      Microsoft.Build.Locator as a proper dependency so consumers still restore it.
+      Microsoft.Build.Locator (a dependency of UpdatR.MsBuild) from flowing to UpdatR's nuspec via
+      this path, which matters for the same reason it's kept out of UpdatR's nuspec via its own
+      direct PackageReference below - see that comment for why. The CopyProjectReferencesToPackage
+      target below bundles UpdatR.MsBuild.dll's compiled output directly into UpdatR's own package.
     -->
     <ProjectReference Include="..\UpdatR.MsBuild\UpdatR.MsBuild.csproj" PrivateAssets="all" />
   </ItemGroup>
@@ -53,10 +53,24 @@
   <ItemGroup>
     <!--
       Microsoft.Build.Locator.dll must physically ship next to UpdatR.dll (ModuleInitializer.cs
-      calls into it unconditionally), but PrivateAssets="all" above stops it flowing as a nuspec
-      dependency. Declaring it directly here restores that dependency declaration.
+      calls into it unconditionally). It is intentionally NOT declared as a normal dependency here:
+      Microsoft.Build.Locator ships its own buildTransitive\Microsoft.Build.Locator.targets file,
+      which fails the build (MSBL001) of ANY project that ends up depending on Microsoft.Build.Locator
+      - directly or transitively - unless every PackageReference to an assembly MSBuild ships its own
+      copy of (NuGet.Frameworks among them) has ExcludeAssets="runtime" and PrivateAssets="all" set.
+      That metadata does not flow transitively (see the NuGet.Frameworks comment above), so if
+      Microsoft.Build.Locator flowed to consumers as a normal dependency, EVERY consumer of the
+      UpdatR package would fail to build with MSBL001, through no fault of their own, as soon as
+      they add a PackageReference to UpdatR (confirmed: there is currently no way, via buildTransitive
+      or otherwise, to make the required exclusion metadata flow transitively - see
+      https://github.com/microsoft/MSBuildLocator/issues/364). PrivateAssets="all" keeps
+      Microsoft.Build.Locator out of UpdatR's nuspec entirely, so its buildTransitive check never
+      even gets imported into a consumer's build. The CopyProjectReferencesToPackage target below
+      bundles its compiled output directly into UpdatR's own package instead, so UpdatR.dll's
+      ModuleInitializer still finds it at run-time without consumers ever restoring the package
+      themselves.
     -->
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" PrivateAssets="all" />
   </ItemGroup>
 
   <!--
@@ -65,7 +79,8 @@
     https://learn.microsoft.com/nuget/create-packages/set-package-type#including-referenced-projects-in-the-nuget-package).
     This target copies UpdatR.MsBuild.dll (and its own copy-local outputs) into UpdatR's package
     alongside UpdatR.dll, so consumers actually get the assembly UpdatR.dll's ModuleInitializer and
-    PropsFile support depend on at runtime.
+    PropsFile support depend on at runtime. It also bundles Microsoft.Build.Locator.dll itself (see
+    the PrivateAssets="all" comment above for why it isn't a normal dependency).
   -->
   <PropertyGroup>
     <TargetsForTfmSpecificBuildOutput>
@@ -73,9 +88,18 @@
     </TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
-  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+  <Target
+    Name="CopyProjectReferencesToPackage"
+    DependsOnTargets="ResolveReferences;ResolvePackageAssets"
+  >
     <ItemGroup>
       <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('NuGetPackageId', ''))" />
+      <!--
+        UpdatR is a class library, so Microsoft.Build.Locator.dll is never copy-local to UpdatR's
+        own build output (that only happens for executable projects) - RuntimeCopyLocalItems still
+        lists it (with its resolved path) regardless, which is what's needed here.
+      -->
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'Microsoft.Build.Locator'))" />
     </ItemGroup>
   </Target>
 

--- a/src/dotnet-updatr/dotnet-updatr.csproj
+++ b/src/dotnet-updatr/dotnet-updatr.csproj
@@ -38,6 +38,16 @@
     <PackageReference Include="NuGet.Protocol" Version="7.9.0" />
     <PackageReference Include="NuGet.Versioning" Version="7.9.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.11" />
+    <!--
+      Needed directly: UpdatR.csproj marks its own Microsoft.Build.Locator PackageReference
+      PrivateAssets="all" (see the comment there), which also stops it flowing transitively via
+      the ProjectReference below. That's fine for real consumers of the published UpdatR NuGet
+      package (its DLL is bundled directly into UpdatR's package instead), but dotnet-updatr
+      consumes UpdatR via ProjectReference, not the packed .nupkg, so it must reference the same
+      version itself to get Microsoft.Build.Locator.dll copied to its own output - UpdatR.dll's
+      ModuleInitializer requires it to be physically present at runtime.
+    -->
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UpdatR.E2eTests/LiveTests.cs
+++ b/tests/UpdatR.E2eTests/LiveTests.cs
@@ -3,6 +3,7 @@ using static SimpleExec.Command;
 
 namespace UpdatR.E2e;
 
+[Collection("E2E sequential")]
 public sealed class LiveTests : IDisposable
 {
     private readonly TextWriter _originalConsoleOut;

--- a/tests/UpdatR.E2eTests/PackageConsumerTests.cs
+++ b/tests/UpdatR.E2eTests/PackageConsumerTests.cs
@@ -1,0 +1,165 @@
+using Xunit;
+using static SimpleExec.Command;
+
+namespace UpdatR.E2e;
+
+/// <summary>
+/// Packs UpdatR as a real NuGet package and consumes it from a brand new console project via a
+/// plain PackageReference - the same way an actual user would. This is the only test in the repo
+/// that goes through NuGet's real restore/pack graph resolution instead of a ProjectReference, so
+/// it's the only place that would have caught the MSBL001 regression ("A PackageReference to the
+/// package 'NuGet.Frameworks' ... without ExcludeAssets='runtime' and PrivateAssets='all' set")
+/// that shipped in 6.0.0-beta.0: every other test in the solution references UpdatR.csproj via
+/// ProjectReference, which never exercises NuGet's transitive-dependency/asset-exclusion logic.
+/// </summary>
+public sealed class PackageConsumerTests : IDisposable
+{
+    private readonly TextWriter _originalConsoleOut;
+    private readonly TestOutputHelperTextWriterAdapter _outAdapter;
+    private bool disposedValue;
+
+    public PackageConsumerTests(ITestOutputHelper output)
+    {
+        _originalConsoleOut = Console.Out;
+        _outAdapter = new TestOutputHelperTextWriterAdapter(output);
+
+        Console.SetOut(_outAdapter);
+    }
+
+    [Fact]
+    public async Task ConsumeUpdatRPackageBuildAndRunSucceedWithoutMsbl001()
+    {
+        var root = await GetRepoRootDirectoryAsync();
+
+        Console.WriteLine("Root: " + root);
+
+        var testTemp = Path.Combine(
+            Path.GetTempPath(),
+            "dotnet-updatr",
+            "e2etests-packageconsumer"
+        );
+
+        if (Directory.Exists(testTemp))
+        {
+            Directory.Delete(testTemp, true);
+        }
+
+        Directory.CreateDirectory(testTemp);
+
+        var localFeed = Path.Combine(testTemp, "feed");
+        var consumerDir = Path.Combine(testTemp, "Consumer");
+
+        Directory.CreateDirectory(localFeed);
+
+        // Unique per test run so nothing can be served from a NuGet cache from a previous run.
+        var testVersion = $"0.0.1-e2etest.{DateTime.UtcNow:yyyyMMddHHmmssfff}";
+
+        var updatrProjectPath = Path.Combine(root.FullName, "src", "UpdatR", "UpdatR.csproj");
+
+        await RunAsync(
+            "dotnet",
+            $"pack \"{updatrProjectPath}\" --configuration Release -p:PackageVersion={testVersion} -o \"{localFeed}\"",
+            ct: TestContext.Current.CancellationToken
+        );
+
+        await RunAsync(
+            "dotnet",
+            $"new console -o \"{consumerDir}\" --force",
+            ct: TestContext.Current.CancellationToken
+        );
+
+        await File.WriteAllTextAsync(
+            Path.Combine(consumerDir, "nuget.config"),
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+                <add key="local-updatr-feed" value="{localFeed}" />
+              </packageSources>
+            </configuration>
+            """,
+            TestContext.Current.CancellationToken
+        );
+
+        await RunAsync(
+            "dotnet",
+            $"add \"{consumerDir}\" package UpdatR --version {testVersion} --source \"{localFeed}\"",
+            ct: TestContext.Current.CancellationToken
+        );
+
+        var (buildStdOutput, buildStdError) = await ReadAsync(
+            "dotnet",
+            "build --configuration Release",
+            workingDirectory: consumerDir,
+            ct: TestContext.Current.CancellationToken
+        );
+
+        Console.WriteLine("Build stdout:");
+        Console.WriteLine(buildStdOutput);
+        Console.WriteLine("Build stderr:");
+        Console.WriteLine(buildStdError);
+
+        // ReadAsync (SimpleExec) throws on a non-zero exit code, so a build failure (including
+        // MSBuildLocator's MSBL001 hard error) already fails this test on its own. The extra
+        // assertion is defense-in-depth in case the check is ever downgraded to a warning.
+        Assert.DoesNotContain("MSBL001", buildStdOutput, StringComparison.OrdinalIgnoreCase);
+
+        // Exercise the actual runtime behavior too (ModuleInitializer registering
+        // MSBuildLocator, and UpdatR.MsBuild actually resolving a real MSBuild), not just the
+        // build - the DLL needs to both be present (build-time check above) and loadable.
+        await File.WriteAllTextAsync(
+            Path.Combine(consumerDir, "Program.cs"),
+            $"""
+            var updater = new UpdatR.Updater();
+            var summary = await updater.UpdateAsync(@"{consumerDir}", dryRun: true);
+            Console.WriteLine("UpdatR ran successfully. Updated packages: " + summary.UpdatedPackagesCount);
+            """,
+            TestContext.Current.CancellationToken
+        );
+
+        var (runStdOutput, runStdError) = await ReadAsync(
+            "dotnet",
+            "run --configuration Release",
+            workingDirectory: consumerDir,
+            ct: TestContext.Current.CancellationToken
+        );
+
+        Console.WriteLine("Run stdout:");
+        Console.WriteLine(runStdOutput);
+        Console.WriteLine("Run stderr:");
+        Console.WriteLine(runStdError);
+
+        Assert.Contains("UpdatR ran successfully.", runStdOutput, StringComparison.Ordinal);
+    }
+
+    private static async Task<DirectoryInfo> GetRepoRootDirectoryAsync()
+    {
+        var (stdOutput, stdError) = await ReadAsync("git", "rev-parse --show-toplevel");
+
+        return new DirectoryInfo(stdOutput.Trim());
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (!disposedValue)
+        {
+            if (disposing)
+            {
+                Console.SetOut(_originalConsoleOut);
+
+                _outAdapter.Dispose();
+            }
+
+            disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/UpdatR.E2eTests/PackageConsumerTests.cs
+++ b/tests/UpdatR.E2eTests/PackageConsumerTests.cs
@@ -4,6 +4,17 @@ using static SimpleExec.Command;
 namespace UpdatR.E2e;
 
 /// <summary>
+/// Both LiveTests and PackageConsumerTests spawn heavy "dotnet" subprocesses and temporarily
+/// redirect the process-wide Console.Out to capture output for xunit. xunit runs different test
+/// classes in parallel by default, and Console.Out is global mutable state, so without this
+/// collection the two classes' captured output can get interleaved/corrupted when they run at the
+/// same time (observed in CI: PackageConsumerTests' failure output contained LiveTests' Dummy.App
+/// output). Putting both in the same collection forces them to run sequentially instead.
+/// </summary>
+[CollectionDefinition("E2E sequential", DisableParallelization = true)]
+public sealed class E2eSequentialFixture;
+
+/// <summary>
 /// Packs UpdatR as a real NuGet package and consumes it from a brand new console project via a
 /// plain PackageReference - the same way an actual user would. This is the only test in the repo
 /// that goes through NuGet's real restore/pack graph resolution instead of a ProjectReference, so
@@ -12,6 +23,7 @@ namespace UpdatR.E2e;
 /// that shipped in 6.0.0-beta.0: every other test in the solution references UpdatR.csproj via
 /// ProjectReference, which never exercises NuGet's transitive-dependency/asset-exclusion logic.
 /// </summary>
+[Collection("E2E sequential")]
 public sealed class PackageConsumerTests : IDisposable
 {
     private readonly TextWriter _originalConsoleOut;
@@ -89,6 +101,20 @@ public sealed class PackageConsumerTests : IDisposable
             ct: TestContext.Current.CancellationToken
         );
 
+        // Write Program.cs before building, so a single build produces a binary that both
+        // proves there's no MSBL001 build error AND can immediately be executed afterwards -
+        // avoids relying on `dotnet run`'s own incremental up-to-date checks re-triggering (or
+        // not) a full rebuild.
+        await File.WriteAllTextAsync(
+            Path.Combine(consumerDir, "Program.cs"),
+            $"""
+            var updater = new UpdatR.Updater();
+            var summary = await updater.UpdateAsync(@"{consumerDir}", dryRun: true);
+            Console.WriteLine("UpdatR ran successfully. Updated packages: " + summary.UpdatedPackagesCount);
+            """,
+            TestContext.Current.CancellationToken
+        );
+
         var (buildStdOutput, buildStdError) = await ReadAsync(
             "dotnet",
             "build --configuration Release",
@@ -108,20 +134,19 @@ public sealed class PackageConsumerTests : IDisposable
 
         // Exercise the actual runtime behavior too (ModuleInitializer registering
         // MSBuildLocator, and UpdatR.MsBuild actually resolving a real MSBuild), not just the
-        // build - the DLL needs to both be present (build-time check above) and loadable.
-        await File.WriteAllTextAsync(
-            Path.Combine(consumerDir, "Program.cs"),
-            $"""
-            var updater = new UpdatR.Updater();
-            var summary = await updater.UpdateAsync(@"{consumerDir}", dryRun: true);
-            Console.WriteLine("UpdatR ran successfully. Updated packages: " + summary.UpdatedPackagesCount);
-            """,
-            TestContext.Current.CancellationToken
-        );
+        // build - the DLL needs to both be present (build-time check above) and loadable. Uses
+        // `dotnet exec` against the binary just built, the same proven pattern LiveTests uses for
+        // the CLI, instead of `dotnet run` (which would re-evaluate/rebuild the project again).
+        var consumerDll = Path.Combine(consumerDir, "bin", "Release", "net10.0", "Consumer.dll");
+
+        if (!File.Exists(consumerDll))
+        {
+            throw new InvalidOperationException($"Could not find built assembly at {consumerDll}.");
+        }
 
         var (runStdOutput, runStdError) = await ReadAsync(
             "dotnet",
-            "run --configuration Release",
+            $"exec \"{consumerDll}\"",
             workingDirectory: consumerDir,
             ct: TestContext.Current.CancellationToken
         );

--- a/tests/UpdatR.E2eTests/PackageConsumerTests.cs
+++ b/tests/UpdatR.E2eTests/PackageConsumerTests.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using Xunit;
 using static SimpleExec.Command;
 
@@ -74,6 +75,38 @@ public sealed class PackageConsumerTests : IDisposable
             ct: TestContext.Current.CancellationToken
         );
 
+        // Diagnostic, defense-in-depth check: assert the produced .nupkg actually contains both
+        // UpdatR.dll's runtime dependencies (UpdatR.MsBuild.dll, Microsoft.Build.Locator.dll)
+        // alongside UpdatR.dll itself. These are bundled by the CopyProjectReferencesToPackage
+        // target in UpdatR.csproj instead of being normal NuGet dependencies (see the comments
+        // there) - if that target's item-filtering ever silently stops matching (e.g. an MSBuild
+        // version/OS difference in how ReferenceCopyLocalPaths/RuntimeCopyLocalItems metadata gets
+        // populated), this fails right here at pack-time instead of showing up as a confusing
+        // runtime FileNotFoundException in the consumer app further down.
+        var nupkgPath = Path.Combine(localFeed, $"UpdatR.{testVersion}.nupkg");
+
+        Assert.True(File.Exists(nupkgPath), $"Expected package not found at {nupkgPath}.");
+
+        using (var archive = ZipFile.OpenRead(nupkgPath))
+        {
+            var libEntries = archive
+                .Entries.Where(e => e.FullName.StartsWith("lib/", StringComparison.Ordinal))
+                .Select(e => e.FullName)
+                .ToArray();
+
+            Console.WriteLine("Package lib/ entries: " + string.Join(", ", libEntries));
+
+            Assert.Contains(libEntries, e => e.EndsWith("UpdatR.dll", StringComparison.Ordinal));
+            Assert.Contains(
+                libEntries,
+                e => e.EndsWith("UpdatR.MsBuild.dll", StringComparison.Ordinal)
+            );
+            Assert.Contains(
+                libEntries,
+                e => e.EndsWith("Microsoft.Build.Locator.dll", StringComparison.Ordinal)
+            );
+        }
+
         await RunAsync(
             "dotnet",
             $"new console -o \"{consumerDir}\" --force",
@@ -131,6 +164,23 @@ public sealed class PackageConsumerTests : IDisposable
         // MSBuildLocator's MSBL001 hard error) already fails this test on its own. The extra
         // assertion is defense-in-depth in case the check is ever downgraded to a warning.
         Assert.DoesNotContain("MSBL001", buildStdOutput, StringComparison.OrdinalIgnoreCase);
+
+        // Diagnostic, defense-in-depth check: assert UpdatR's bundled runtime dependencies
+        // actually got copied into the consumer app's own output directory by NuGet/MSBuild
+        // during the build above - not just present in the .nupkg (checked earlier). If this ever
+        // fails, the break is in restore/copy-local resolution rather than in packing.
+        var consumerOutputDir = Path.Combine(consumerDir, "bin", "Release", "net10.0");
+
+        var consumerOutputFiles = Directory.Exists(consumerOutputDir)
+            ? Directory.GetFiles(consumerOutputDir).Select(Path.GetFileName).ToArray()
+            : [];
+
+        Console.WriteLine(
+            "Consumer output directory contents: " + string.Join(", ", consumerOutputFiles)
+        );
+
+        Assert.Contains("UpdatR.MsBuild.dll", consumerOutputFiles);
+        Assert.Contains("Microsoft.Build.Locator.dll", consumerOutputFiles);
 
         // Exercise the actual runtime behavior too (ModuleInitializer registering
         // MSBuildLocator, and UpdatR.MsBuild actually resolving a real MSBuild), not just the

--- a/tests/UpdatR.IntegrationTests/UpdatR.IntegrationTests.csproj
+++ b/tests/UpdatR.IntegrationTests/UpdatR.IntegrationTests.csproj
@@ -13,6 +13,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
+    <!--
+      Needed directly: UpdatR.csproj marks its own Microsoft.Build.Locator PackageReference
+      PrivateAssets="all" (see the comment there), which also stops it flowing transitively via
+      the ProjectReference below. This project consumes UpdatR via ProjectReference, not the
+      packed .nupkg, so it must reference the same version itself to get
+      Microsoft.Build.Locator.dll copied to its own output - UpdatR.dll's ModuleInitializer
+      requires it to be physically present at runtime.
+    -->
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageReference Include="Verify.XunitV3" Version="32.0.0" />
     <PackageReference Include="xunit.v3" Version="4.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">

--- a/tests/UpdatR.UnitTests/UpdatR.UnitTests.csproj
+++ b/tests/UpdatR.UnitTests/UpdatR.UnitTests.csproj
@@ -11,10 +11,10 @@
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
     <!--
       Needed directly: UpdatR.csproj no longer flows this transitively (see the comment on the
-      same PackageReference there). Must be excluded here too, since Microsoft.Build.Locator
-      reaches this project transitively via the ProjectReference to UpdatR below. Because this
-      project (unlike UpdatR.dll) has no guaranteed entry point, ModuleInitializer.cs in this
-      project registers MSBuildLocator before any test can run.
+      same PackageReference there). Must be excluded here too, since Microsoft.Build.Locator is
+      referenced directly below (needed for the same reason). Because this project (unlike
+      UpdatR.dll) has no guaranteed entry point, ModuleInitializer.cs in this project registers
+      MSBuildLocator before any test can run.
     -->
     <PackageReference
       Include="NuGet.Frameworks"
@@ -22,6 +22,14 @@
       ExcludeAssets="runtime"
       PrivateAssets="all"
     />
+    <!--
+      Needed directly: UpdatR.csproj marks its own Microsoft.Build.Locator PackageReference
+      PrivateAssets="all" (see the comment there), which also stops it flowing transitively via
+      the ProjectReference to UpdatR below. This project consumes UpdatR via ProjectReference,
+      not the packed .nupkg, so it must reference the same version itself to get
+      Microsoft.Build.Locator.dll copied to its own output.
+    -->
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageReference Include="Verify.XunitV3" Version="32.0.0" />
     <PackageReference Include="xunit.v3" Version="4.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">


### PR DESCRIPTION
…'7.9.0' is present in this project without ExcludeAssets="runtime" and PrivateAssets="all" set. This can cause errors at run-time due to MSBuild assembly-loading.