### PR TITLE
Support multi-targeted projects (TargetFrameworks)

### DIFF
--- a/src/UpdatR/Domain/Csproj.cs
+++ b/src/UpdatR/Domain/Csproj.cs
@@ -12,7 +12,7 @@ internal sealed partial class Csproj
 {
     private readonly FileInfo _path;
     private readonly XmlDocument _doc;
-    private NuGetFramework? _targetFramework;
+    private IReadOnlyList<NuGetFramework>? _targetFrameworks;
     private NuGetVersion? _entityFrameworkVersion;
     private bool _entityFrameworkVersionLoaded;
 
@@ -28,7 +28,15 @@ internal sealed partial class Csproj
 
     public string Parent => _path.DirectoryName!;
 
-    public NuGetFramework TargetFramework => _targetFramework ??= GetTargetFramework();
+    /// <summary>
+    /// Every target framework declared by this project - either via a single
+    /// <c>TargetFramework</c>, or a <c>;</c>-separated <c>TargetFrameworks</c> for a
+    /// multi-targeted project. Falls back to whatever is declared in an imported
+    /// <c>Directory.Build.props</c>, or <see cref="NuGetFramework.AnyFramework"/> if none is
+    /// found.
+    /// </summary>
+    public IReadOnlyList<NuGetFramework> TargetFrameworks =>
+        _targetFrameworks ??= GetTargetFrameworks();
 
     public NuGetVersion? EntityFrameworkVersion =>
         _entityFrameworkVersionLoaded
@@ -78,6 +86,8 @@ internal sealed partial class Csproj
         IReadOnlyCollection<string>? allowedLicenses = null
     )
     {
+        var tfms = tfm is null ? TargetFrameworks : [tfm];
+
         var project = new ProjectWithPackages(Path);
 
         var changed = false;
@@ -132,12 +142,13 @@ internal sealed partial class Csproj
             }
 
             if (
-                !package.TryGetLatestComparedTo(
+                !TargetFrameworkCompatibility.TryGetLatestCompatibleWithAllTfms(
+                    package,
                     version,
-                    tfm ?? TargetFramework,
+                    tfms,
                     usePrerelease,
-                    out var updateTo,
-                    allowedLicenses
+                    allowedLicenses,
+                    out var updateTo
                 )
             )
             {
@@ -152,7 +163,7 @@ internal sealed partial class Csproj
                     package,
                     packageId,
                     version,
-                    tfm ?? TargetFramework,
+                    tfms,
                     usePrerelease,
                     allowedLicenses
                 );
@@ -258,19 +269,22 @@ internal sealed partial class Csproj
             NuGetPackage package,
             string packageId,
             NuGetVersion version,
-            NuGetFramework targetFramework,
+            IReadOnlyCollection<NuGetFramework> tfms,
             bool usePrerelease,
             IReadOnlyCollection<string>? allowedLicenses
         )
         {
             if (
-                !package.TryGetNewerVersionWithDisallowedLicense(
+                allowedLicenses is not { Count: > 0 }
+                || !TargetFrameworkCompatibility.TryGetLatestCompatibleWithAllTfms(
+                    package,
                     version,
-                    targetFramework,
+                    tfms,
                     usePrerelease,
-                    allowedLicenses,
+                    allowedLicenses: null,
                     out var skipped
                 )
+                || NuGetPackage.IsLicenseAllowed(skipped, allowedLicenses)
             )
             {
                 return;
@@ -294,15 +308,15 @@ internal sealed partial class Csproj
         }
     }
 
-    private NuGetFramework GetTargetFramework()
+    private NuGetFramework[] GetTargetFrameworks()
     {
-        var targetFramework =
-            RetriveTargetFramework.GetTargetFramework(Path)
-            ?? GetTargetFrameworkFromDirectoryBuildProps(new(Parent));
+        var targetFrameworks =
+            RetriveTargetFramework.GetTargetFrameworks(Path)
+            ?? GetTargetFrameworksFromDirectoryBuildProps(new(Parent));
 
-        return targetFramework is null
-            ? NuGetFramework.AnyFramework
-            : NuGetFramework.Parse(targetFramework);
+        return targetFrameworks is null
+            ? [NuGetFramework.AnyFramework]
+            : targetFrameworks.Select(NuGetFramework.Parse).ToArray();
     }
 
     private void UpdateEntityFrameworkVersion()

--- a/src/UpdatR/Domain/PropsFile.cs
+++ b/src/UpdatR/Domain/PropsFile.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using NuGet.Frameworks;
 using NuGet.Versioning;
+using UpdatR.Domain.Utils;
 using UpdatR.Internals;
 
 namespace UpdatR.Domain;
@@ -137,7 +138,7 @@ internal sealed partial class PropsFile
             }
 
             if (
-                !TryGetLatestCompatibleWithAllTfms(
+                !TargetFrameworkCompatibility.TryGetLatestCompatibleWithAllTfms(
                     package,
                     version,
                     tfms,
@@ -263,7 +264,7 @@ internal sealed partial class PropsFile
         {
             if (
                 allowedLicenses is not { Count: > 0 }
-                || !TryGetLatestCompatibleWithAllTfms(
+                || !TargetFrameworkCompatibility.TryGetLatestCompatibleWithAllTfms(
                     package,
                     version,
                     tfms,
@@ -293,54 +294,6 @@ internal sealed partial class PropsFile
                 candidate.LicenseExpression!
             );
         }
-    }
-
-    /// <summary>
-    /// Finds the latest version of <paramref name="package"/>, newer than <paramref name="from"/>,
-    /// that every framework in <paramref name="tfms"/> can use. If any framework has no valid
-    /// update (i.e. is already on the newest version it supports), no update is returned at all -
-    /// this file may be imported by that framework's project too, so updating further could break
-    /// it. Otherwise, the lowest of the per-framework results is returned, since that's guaranteed
-    /// to be compatible with every framework that imports this file.
-    /// </summary>
-    private static bool TryGetLatestCompatibleWithAllTfms(
-        NuGetPackage package,
-        NuGetVersion from,
-        IReadOnlyCollection<NuGetFramework> tfms,
-        bool usePrerelease,
-        IReadOnlyCollection<string>? allowedLicenses,
-        [System.Diagnostics.CodeAnalysis.NotNullWhen(returnValue: true)]
-            out PackageMetadata? updateTo
-    )
-    {
-        PackageMetadata? lowestCommonUpdate = null;
-
-        foreach (var candidateTfm in tfms)
-        {
-            if (
-                !package.TryGetLatestComparedTo(
-                    from,
-                    candidateTfm,
-                    usePrerelease,
-                    out var updateToForTfm,
-                    allowedLicenses
-                )
-            )
-            {
-                updateTo = null;
-
-                return false;
-            }
-
-            if (lowestCommonUpdate is null || updateToForTfm.Version < lowestCommonUpdate.Version)
-            {
-                lowestCommonUpdate = updateToForTfm;
-            }
-        }
-
-        updateTo = lowestCommonUpdate;
-
-        return updateTo is not null;
     }
 
     private Dictionary<string, NuGetVersion> GetPackages() =>

--- a/src/UpdatR/Domain/RootDir.cs
+++ b/src/UpdatR/Domain/RootDir.cs
@@ -393,7 +393,7 @@ internal sealed class RootDir
                     tfmsByPath[sourceFile] = tfms = [];
                 }
 
-                tfms.Add(csproj.TargetFramework);
+                tfms.AddRange(csproj.TargetFrameworks);
             }
         }
 

--- a/src/UpdatR/Domain/Utils/RetriveTargetFramework.cs
+++ b/src/UpdatR/Domain/Utils/RetriveTargetFramework.cs
@@ -6,11 +6,26 @@ internal static class RetriveTargetFramework
 {
     public static string? GetTargetFrameworkFromDirectoryBuildProps(DirectoryInfo path)
     {
+        var targetFrameworks = GetTargetFrameworksFromDirectoryBuildProps(path);
+
+        return targetFrameworks is null ? null : targetFrameworks[0];
+    }
+
+    /// <summary>
+    /// Walks up from <paramref name="path"/> looking for a <c>Directory.Build.props</c> that
+    /// declares a <c>TargetFramework</c> or <c>TargetFrameworks</c> - stopping as soon as one is
+    /// found that either doesn't import a <c>Directory.Build.props</c> from a parent directory,
+    /// or does declare a target framework.
+    /// </summary>
+    public static IReadOnlyList<string>? GetTargetFrameworksFromDirectoryBuildProps(
+        DirectoryInfo path
+    )
+    {
         var file = GetDirectoryBuildProps(path);
 
-        var targetFramework = file is null ? null : GetTargetFramework(file.FullName);
+        var targetFrameworks = file is null ? null : GetTargetFrameworks(file.FullName);
 
-        while (targetFramework is null)
+        while (targetFrameworks is null)
         {
             // Make sure we don't try to go beyond C:\
             if (Path.GetPathRoot(path.FullName) == path.FullName)
@@ -24,7 +39,7 @@ internal static class RetriveTargetFramework
 
                 file = GetDirectoryBuildProps(path);
 
-                targetFramework = file is null ? null : GetTargetFramework(file.FullName);
+                targetFrameworks = file is null ? null : GetTargetFrameworks(file.FullName);
             }
             else
             {
@@ -32,7 +47,7 @@ internal static class RetriveTargetFramework
             }
         }
 
-        return targetFramework;
+        return targetFrameworks;
 
         static FileInfo? GetDirectoryBuildProps(DirectoryInfo path)
         {
@@ -61,13 +76,41 @@ internal static class RetriveTargetFramework
 
     public static string? GetTargetFramework(string path)
     {
+        var targetFrameworks = GetTargetFrameworks(path);
+
+        return targetFrameworks is null ? null : targetFrameworks[0];
+    }
+
+    /// <summary>
+    /// Reads the target framework(s) declared in the project file at <paramref name="path"/>.
+    /// Prefers a multi-targeted <c>TargetFrameworks</c> (plural, <c>;</c>-separated) property
+    /// group, falling back to a single <c>TargetFramework</c> property. Returns
+    /// <see langword="null"/> if neither is declared.
+    /// </summary>
+    public static IReadOnlyList<string>? GetTargetFrameworks(string path)
+    {
         var doc = new XmlDocument();
 
         doc.Load(path);
 
-        return doc.SelectNodes("/Project/PropertyGroup/TargetFramework")
+        var targetFrameworks = doc.SelectNodes("/Project/PropertyGroup/TargetFrameworks")
+            ?.OfType<XmlElement>()
+            .FirstOrDefault()
+            ?.InnerText;
+
+        if (!string.IsNullOrWhiteSpace(targetFrameworks))
+        {
+            return targetFrameworks
+                .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        var targetFramework = doc.SelectNodes("/Project/PropertyGroup/TargetFramework")
             ?.OfType<XmlElement>()
             .SingleOrDefault()
             ?.InnerText;
+
+        return string.IsNullOrWhiteSpace(targetFramework) ? null : [targetFramework];
     }
 }

--- a/src/UpdatR/Domain/Utils/TargetFrameworkCompatibility.cs
+++ b/src/UpdatR/Domain/Utils/TargetFrameworkCompatibility.cs
@@ -1,0 +1,61 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+using UpdatR.Internals;
+
+namespace UpdatR.Domain.Utils;
+
+/// <summary>
+/// Shared logic for resolving package updates that must be compatible with every target
+/// framework of a multi-targeted <see cref="Csproj"/>, or every project that imports a shared
+/// <see cref="PropsFile"/>.
+/// </summary>
+internal static class TargetFrameworkCompatibility
+{
+    /// <summary>
+    /// Finds the latest version of <paramref name="package"/>, newer than <paramref name="from"/>,
+    /// that every framework in <paramref name="tfms"/> can use. If any framework has no valid
+    /// update (i.e. is already on the newest version it supports), no update is returned at all,
+    /// since a version incompatible with even one of the target frameworks could break the build.
+    /// Otherwise, the lowest of the per-framework results is returned, since that's guaranteed to
+    /// be compatible with every framework in <paramref name="tfms"/>.
+    /// </summary>
+    public static bool TryGetLatestCompatibleWithAllTfms(
+        NuGetPackage package,
+        NuGetVersion from,
+        IReadOnlyCollection<NuGetFramework> tfms,
+        bool usePrerelease,
+        IReadOnlyCollection<string>? allowedLicenses,
+        [NotNullWhen(returnValue: true)] out PackageMetadata? updateTo
+    )
+    {
+        PackageMetadata? lowestCommonUpdate = null;
+
+        foreach (var candidateTfm in tfms)
+        {
+            if (
+                !package.TryGetLatestComparedTo(
+                    from,
+                    candidateTfm,
+                    usePrerelease,
+                    out var updateToForTfm,
+                    allowedLicenses
+                )
+            )
+            {
+                updateTo = null;
+
+                return false;
+            }
+
+            if (lowestCommonUpdate is null || updateToForTfm.Version < lowestCommonUpdate.Version)
+            {
+                lowestCommonUpdate = updateToForTfm;
+            }
+        }
+
+        updateTo = lowestCommonUpdate;
+
+        return updateTo is not null;
+    }
+}

--- a/tests/UpdatR.UnitTests/Domain/CsprojTests.cs
+++ b/tests/UpdatR.UnitTests/Domain/CsprojTests.cs
@@ -2,6 +2,7 @@
 using NuGet.Frameworks;
 using NuGet.Versioning;
 using UpdatR.Domain;
+using UpdatR.Internals;
 
 namespace UpdatR.UnitTests.Domain;
 
@@ -226,6 +227,119 @@ public class CsprojTests : IDisposable
         Assert.Contains("Some.Package", message, StringComparison.Ordinal);
         Assert.Contains("2.0.0", message, StringComparison.Ordinal);
         Assert.Contains("GPL-3.0", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UpdatePackagesOnlyUpdatesToVersionCompatibleWithAllTargetFrameworks()
+    {
+        // Arrange - a multi-targeted (net6.0;net8.0) project can only go to 1.5.0 (2.0.0 only
+        // supports net8.0), so the conservative/common update across both frameworks is 1.5.0,
+        // not 2.0.0.
+        File.WriteAllText(
+            _csprojPath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Some.Package" Version="1.0.0" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        var csproj = Csproj.Create(_csprojPath);
+
+        var package = new NuGetPackage(
+            "Some.Package",
+            [
+                new PackageMetadata(
+                    NuGetVersion.Parse("1.0.0"),
+                    [NuGetFramework.Parse("net6.0"), NuGetFramework.Parse("net8.0")],
+                    null,
+                    null
+                ),
+                new PackageMetadata(
+                    NuGetVersion.Parse("1.5.0"),
+                    [NuGetFramework.Parse("net6.0"), NuGetFramework.Parse("net8.0")],
+                    null,
+                    null
+                ),
+                new PackageMetadata(
+                    NuGetVersion.Parse("2.0.0"),
+                    [NuGetFramework.Parse("net8.0")],
+                    null,
+                    null
+                ),
+            ]
+        );
+
+        // Act
+        var result = csproj.UpdatePackages(
+            new Dictionary<string, NuGetPackage?> { ["Some.Package"] = package },
+            dryRun: true,
+            usePrerelease: false,
+            logger: new FakeLogger()
+        );
+
+        // Assert
+        var updated = Assert.Single(result!.UpdatedPackages);
+
+        Assert.Equal(NuGetVersion.Parse("1.5.0"), updated.To);
+    }
+
+    [Fact]
+    public void UpdatePackagesSkipsUpdateWhenAnyTargetFrameworkHasNoNewerVersion()
+    {
+        // Arrange - version 2.0.0 only targets net8.0, so the net472 part of this multi-targeted
+        // project can't use it. Nothing should be updated even though the net8.0 part could move
+        // to 2.0.0, since that could break the build for net472.
+        File.WriteAllText(
+            _csprojPath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFrameworks>net472;net8.0</TargetFrameworks>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Some.Package" Version="1.0.0" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        var csproj = Csproj.Create(_csprojPath);
+
+        var package = new NuGetPackage(
+            "Some.Package",
+            [
+                new PackageMetadata(
+                    NuGetVersion.Parse("1.0.0"),
+                    [NuGetFramework.Parse("net472"), NuGetFramework.Parse("net8.0")],
+                    null,
+                    null
+                ),
+                new PackageMetadata(
+                    NuGetVersion.Parse("2.0.0"),
+                    [NuGetFramework.Parse("net8.0")],
+                    null,
+                    null
+                ),
+            ]
+        );
+
+        // Act
+        var result = csproj.UpdatePackages(
+            new Dictionary<string, NuGetPackage?> { ["Some.Package"] = package },
+            dryRun: true,
+            usePrerelease: false,
+            logger: new FakeLogger()
+        );
+
+        // Assert
+        Assert.Null(result);
+        Assert.Contains("""Version="1.0.0" """.Trim(), File.ReadAllText(_csprojPath));
     }
 
     private sealed class FakeLogger : ILogger


### PR DESCRIPTION
Closes #51.

Csproj previously only read the singular <TargetFramework> element, so multi-targeted projects (<TargetFrameworks>net6.0;net8.0</TargetFrameworks>) fell back to NuGetFramework.AnyFramework, meaning package compatibility against the actual target frameworks wasn't checked at all.

Csproj now exposes TargetFrameworks (parsed from either TargetFramework or TargetFrameworks, with the same Directory.Build.props fallback as before) and, like PropsFile already did for props/targets files shared by several projects, only updates a package to a version compatible with every target framework - picking the lowest common compatible version, and skipping the update entirely if any framework has none available.

The compatibility resolution logic duplicated between Csproj and PropsFile is extracted into a shared TargetFrameworkCompatibility utility.

### Tests
- Added CsprojTests.UpdatePackagesOnlyUpdatesToVersionCompatibleWithAllTargetFrameworks`n- Added CsprojTests.UpdatePackagesSkipsUpdateWhenAnyTargetFrameworkHasNoNewerVersion`n- Full suite (155 tests) passes via dotnet run Build.cs -- test --parallel.