### PR TITLE
feat: Add support for .updatrrc config file (#191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ If you don't want to allow packages with certain licenses to be installed you ca
 
 Packages without any license metadata are always allowed, and this only affects installing new versions - it will neither touch nor warn about already installed packages that don't match, unless a newer version is available.
 
+If UpdatR fails to find the correct lowest TFM to support, for example for projects that supports multiple TFM's, then it's possible to set the TFM manually:
+
+```
+> update --tfm net6.0
+```
+
+### `.updatrrc` config file
+
 Instead of (or in addition to) `--exclude-package` and `--allowed-licenses` you can add a `.updatrrc` JSON file, either next to the target path or in the current working directory:
 
 ```json
@@ -94,12 +102,6 @@ Instead of (or in addition to) `--exclude-package` and `--allowed-licenses` you 
 ```
 
 Both properties are optional, and any value in `.updatrrc` is merged with the corresponding command line option, if given.
-
-If UpdatR fails to find the correct lowest TFM to support, for example for projects that supports multiple TFM's, then it's possible to set the TFM manually:
-
-```
-> update --tfm net6.0
-```
 
 ### As part of CI/CD
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ If you don't want to update a package or packages you can exclude them:
 > update --exclude-package Microsoft.* --exclude-package Newtonsoft.*
 ```
 
+If you don't want to allow packages with certain licenses to be installed you can specify which licenses are allowed:
+
+```
+> update --allowed-licenses MIT --allowed-licenses Apache-2.0
+```
+
+Packages without any license metadata are always allowed, and this only affects installing new versions - it will neither touch nor warn about already installed packages that don't match, unless a newer version is available.
+
+Instead of (or in addition to) `--exclude-package` and `--allowed-licenses` you can add a `.updatrrc` JSON file, either next to the target path or in the current working directory:
+
+```json
+{
+  "excludePackages": ["Microsoft.*", "Newtonsoft.*"],
+  "allowedLicenses": ["MIT", "Apache-2.0"]
+}
+```
+
+Both properties are optional, and any value in `.updatrrc` is merged with the corresponding command line option, if given.
+
 If UpdatR fails to find the correct lowest TFM to support, for example for projects that supports multiple TFM's, then it's possible to set the TFM manually:
 
 ```
@@ -112,7 +131,7 @@ Arguments:
 
 Options:
   --package <package>                                                Package to update. Supports * as wildcard. Will update all unless specified.
-  --exclude-package <exclude-package>                                Package to exclude. Supports * as wildcard.
+  --exclude-package <exclude-package>                                Package to exclude. Supports * as wildcard. Merged with "excludePackages" from a .updatrrc file, if present.
   --output <output>                                                  Writes the summary to a file. If an existing directory is given, an "output.md" file is created there. If a file path is given, its extension decides the format: ".md" for markdown or ".txt" for plain text.
   --title <title>                                                    Outputs title to path.
   --description <description>                                        Outputs description to path.
@@ -122,7 +141,7 @@ Options:
   --browser                                                          Open summary in browser.
   --interactive                                                      Interaction with user is possible.
   --tfm <tfm>                                                        Lowest TFM to support.
-  --allowed-licenses <allowed-licenses>                              Only update to (and warn about) versions whose license contains one of these values, e.g. 'MIT'. Packages without license information are always allowed. Leave out to disable license checking.
+  --allowed-licenses <allowed-licenses>                              Only update to (and warn about) versions whose license contains one of these values, e.g. 'MIT'. Packages without license information are always allowed. Leave out to disable license checking. Merged with "allowedLicenses" from a .updatrrc file, if present.
   -?, -h, --help                                                     Show help and usage information
   --version                                                          Show version information
 ```

--- a/mdsource/cli-readme.include.md
+++ b/mdsource/cli-readme.include.md
@@ -73,6 +73,14 @@ If you don't want to allow packages with certain licenses to be installed you ca
 
 Packages without any license metadata are always allowed, and this only affects installing new versions - it will neither touch nor warn about already installed packages that don't match, unless a newer version is available.
 
+If UpdatR fails to find the correct lowest TFM to support, for example for projects that supports multiple TFM's, then it's possible to set the TFM manually:
+
+```
+> update --tfm net6.0
+```
+
+### `.updatrrc` config file
+
 Instead of (or in addition to) `--exclude-package` and `--allowed-licenses` you can add a `.updatrrc` JSON file, either next to the target path or in the current working directory:
 
 ```json
@@ -83,12 +91,6 @@ Instead of (or in addition to) `--exclude-package` and `--allowed-licenses` you 
 ```
 
 Both properties are optional, and any value in `.updatrrc` is merged with the corresponding command line option, if given.
-
-If UpdatR fails to find the correct lowest TFM to support, for example for projects that supports multiple TFM's, then it's possible to set the TFM manually:
-
-```
-> update --tfm net6.0
-```
 
 ### As part of CI/CD
 

--- a/mdsource/cli-readme.include.md
+++ b/mdsource/cli-readme.include.md
@@ -65,6 +65,25 @@ If you don't want to update a package or packages you can exclude them:
 > update --exclude-package Microsoft.* --exclude-package Newtonsoft.*
 ```
 
+If you don't want to allow packages with certain licenses to be installed you can specify which licenses are allowed:
+
+```
+> update --allowed-licenses MIT --allowed-licenses Apache-2.0
+```
+
+Packages without any license metadata are always allowed, and this only affects installing new versions - it will neither touch nor warn about already installed packages that don't match, unless a newer version is available.
+
+Instead of (or in addition to) `--exclude-package` and `--allowed-licenses` you can add a `.updatrrc` JSON file, either next to the target path or in the current working directory:
+
+```json
+{
+  "excludePackages": ["Microsoft.*", "Newtonsoft.*"],
+  "allowedLicenses": ["MIT", "Apache-2.0"]
+}
+```
+
+Both properties are optional, and any value in `.updatrrc` is merged with the corresponding command line option, if given.
+
 If UpdatR fails to find the correct lowest TFM to support, for example for projects that supports multiple TFM's, then it's possible to set the TFM manually:
 
 ```

--- a/mdsource/cli-usage.txt
+++ b/mdsource/cli-usage.txt
@@ -6,7 +6,7 @@ Arguments:
 
 Options:
   --package <package>                                                Package to update. Supports * as wildcard. Will update all unless specified.
-  --exclude-package <exclude-package>                                Package to exclude. Supports * as wildcard.
+  --exclude-package <exclude-package>                                Package to exclude. Supports * as wildcard. Merged with "excludePackages" from a .updatrrc file, if present.
   --output <output>                                                  Writes the summary to a file. If an existing directory is given, an "output.md" file is created there. If a file path is given, its extension decides the format: ".md" for markdown or ".txt" for plain text.
   --title <title>                                                    Outputs title to path.
   --description <description>                                        Outputs description to path.
@@ -16,7 +16,7 @@ Options:
   --browser                                                          Open summary in browser.
   --interactive                                                      Interaction with user is possible.
   --tfm <tfm>                                                        Lowest TFM to support.
-  --allowed-licenses <allowed-licenses>                              Only update to (and warn about) versions whose license contains one of these values, e.g. 'MIT'. Packages without license information are always allowed. Leave out to disable license checking.
+  --allowed-licenses <allowed-licenses>                              Only update to (and warn about) versions whose license contains one of these values, e.g. 'MIT'. Packages without license information are always allowed. Leave out to disable license checking. Merged with "allowedLicenses" from a .updatrrc file, if present.
   -?, -h, --help                                                     Show help and usage information
   --version                                                          Show version information
 

--- a/src/Build/docs/release-notes.txt
+++ b/src/Build/docs/release-notes.txt
@@ -2,3 +2,4 @@
 - breaking: To support .props and .targets files, UpdatR now requires the .NET SDK to be installed on the machine.
 - Add `--allowed-licenses` option to filter package updates by license expression (case-insensitive substring match). Packages without license information are always allowed. The currently installed version is also checked and reported as a mismatch if applicable.
 - breaking: `Updater.UpdateAsync` has a new optional `allowedLicenses` parameter and `Summary` has a new `LicenseMismatchPackages` property.
+- Add support for a `.updatrrc` JSON config file with `excludePackages` and `allowedLicenses`. The file is looked up next to the target path, falling back to the current working directory, and its values are merged with the corresponding command line options / `Updater.UpdateAsync` parameters.

--- a/src/UpdatR/Internals/UpdatRConfig.cs
+++ b/src/UpdatR/Internals/UpdatRConfig.cs
@@ -1,0 +1,94 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace UpdatR.Internals;
+
+/// <summary>
+/// Optional JSON config file (<c>.updatrrc</c>) that can be used instead of, or together with,
+/// command line arguments / <see cref="Updater.UpdateAsync"/> parameters.
+/// </summary>
+internal sealed record UpdatRConfig(
+    [property: JsonPropertyName("excludePackages")] string[]? ExcludePackages,
+    [property: JsonPropertyName("allowedLicenses")] string[]? AllowedLicenses
+)
+{
+    internal const string FileName = ".updatrrc";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Looks for a <c>.updatrrc</c> file, first next to <paramref name="path"/> (i.e. in
+    /// <paramref name="path"/> itself if it's a directory, or its parent directory if it's a
+    /// file) and, if not found there, in the current working directory.
+    /// </summary>
+    internal static UpdatRConfig? Load(string path)
+    {
+        var filePath = FindConfigFile(path);
+
+        if (filePath is null)
+        {
+            return null;
+        }
+
+        var json = File.ReadAllText(filePath);
+
+        return JsonSerializer.Deserialize<UpdatRConfig>(json, JsonOptions);
+    }
+
+    private static string? FindConfigFile(string path)
+    {
+        var targetDirectory = ResolveDirectory(path);
+        var candidate = System.IO.Path.Combine(targetDirectory, FileName);
+
+        if (File.Exists(candidate))
+        {
+            return candidate;
+        }
+
+        var currentDirectory = Directory.GetCurrentDirectory();
+
+        if (
+            string.Equals(
+                System.IO.Path.GetFullPath(targetDirectory),
+                System.IO.Path.GetFullPath(currentDirectory),
+                StringComparison.OrdinalIgnoreCase
+            )
+        )
+        {
+            return null;
+        }
+
+        candidate = System.IO.Path.Combine(currentDirectory, FileName);
+
+        return File.Exists(candidate) ? candidate : null;
+    }
+
+    private static string ResolveDirectory(string path)
+    {
+        if (File.Exists(path))
+        {
+            return new FileInfo(path).DirectoryName ?? Directory.GetCurrentDirectory();
+        }
+
+        return Directory.Exists(path) ? path : Directory.GetCurrentDirectory();
+    }
+
+    /// <summary>
+    /// Merges CLI/parameter values with config file values (union, case-insensitive,
+    /// order-preserving, CLI/parameter values first).
+    /// </summary>
+    internal static string[]? Merge(string[]? fromArgs, string[]? fromConfig)
+    {
+        if (fromArgs is null || fromArgs.Length == 0)
+        {
+            return fromConfig;
+        }
+
+        if (fromConfig is null || fromConfig.Length == 0)
+        {
+            return fromArgs;
+        }
+
+        return fromArgs.Concat(fromConfig).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+}

--- a/src/UpdatR/Updater.cs
+++ b/src/UpdatR/Updater.cs
@@ -34,6 +34,12 @@ public sealed partial class Updater(ILogger<Updater>? logger = null)
     /// allowed. Packages without any license metadata are always allowed. Leave out or empty to
     /// disable license checking.
     /// </param>
+    /// <remarks>
+    /// If a <c>.updatrrc</c> JSON file is found - first next to <paramref name="path"/>, then in
+    /// the current working directory - its <c>excludePackages</c> and <c>allowedLicenses</c>
+    /// values are merged (union) with <paramref name="excludePackages"/> and
+    /// <paramref name="allowedLicenses"/> respectively.
+    /// </remarks>
     /// <returns><see cref="Summary"/></returns>
     /// <exception cref="ArgumentException"></exception>
     public async Task<Summary> UpdateAsync(
@@ -50,6 +56,11 @@ public sealed partial class Updater(ILogger<Updater>? logger = null)
         var tfm = ParseTFM(targetFrameworkMoniker);
 
         path ??= Directory.GetCurrentDirectory();
+
+        var updatRConfig = UpdatRConfig.Load(path);
+
+        excludePackages = UpdatRConfig.Merge(excludePackages, updatRConfig?.ExcludePackages);
+        allowedLicenses = UpdatRConfig.Merge(allowedLicenses, updatRConfig?.AllowedLicenses);
 
         var shouldIncludePackage = CreateSearch(packages, treatNullOrEmptyAs: true);
         var shouldExcludePackage = CreateSearch(excludePackages, treatNullOrEmptyAs: false);

--- a/src/UpdatR/docs/release-notes.txt
+++ b/src/UpdatR/docs/release-notes.txt
@@ -2,3 +2,4 @@
 - breaking: To support .props and .targets files, UpdatR now requires the .NET SDK to be installed on the machine.
 - Add `--allowed-licenses` option to filter package updates by license expression (case-insensitive substring match). Packages without license information are always allowed. The currently installed version is also checked and reported as a mismatch if applicable.
 - breaking: `Updater.UpdateAsync` has a new optional `allowedLicenses` parameter and `Summary` has a new `LicenseMismatchPackages` property.
+- Add support for a `.updatrrc` JSON config file with `excludePackages` and `allowedLicenses`. The file is looked up next to the target path, falling back to the current working directory, and its values are merged with the corresponding command line options / `Updater.UpdateAsync` parameters.

--- a/src/dotnet-updatr/Program.cs
+++ b/src/dotnet-updatr/Program.cs
@@ -32,7 +32,8 @@ internal static partial class Program
 
         var excludePackageOption = new Option<string[]>("--exclude-package")
         {
-            Description = "Package to exclude. Supports * as wildcard.",
+            Description =
+                "Package to exclude. Supports * as wildcard. Merged with \"excludePackages\" from a .updatrrc file, if present.",
             DefaultValueFactory = _ => [],
         };
 
@@ -80,7 +81,7 @@ internal static partial class Program
         var allowedLicensesOption = new Option<string[]>("--allowed-licenses")
         {
             Description =
-                "Only update to (and warn about) versions whose license contains one of these values, e.g. 'MIT'. Packages without license information are always allowed. Leave out to disable license checking.",
+                "Only update to (and warn about) versions whose license contains one of these values, e.g. 'MIT'. Packages without license information are always allowed. Leave out to disable license checking. Merged with \"allowedLicenses\" from a .updatrrc file, if present.",
             DefaultValueFactory = _ => [],
         };
 

--- a/src/dotnet-updatr/docs/release-notes.txt
+++ b/src/dotnet-updatr/docs/release-notes.txt
@@ -2,3 +2,4 @@
 - breaking: To support .props and .targets files, UpdatR now requires the .NET SDK to be installed on the machine.
 - Add `--allowed-licenses` option to filter package updates by license expression (case-insensitive substring match). Packages without license information are always allowed. The currently installed version is also checked and reported as a mismatch if applicable.
 - breaking: `Updater.UpdateAsync` has a new optional `allowedLicenses` parameter and `Summary` has a new `LicenseMismatchPackages` property.
+- Add support for a `.updatrrc` JSON config file with `excludePackages` and `allowedLicenses`. The file is looked up next to the target path, falling back to the current working directory, and its values are merged with `--exclude-package` / `--allowed-licenses`.

--- a/tests/UpdatR.IntegrationTests/FileCreationUtils.cs
+++ b/tests/UpdatR.IntegrationTests/FileCreationUtils.cs
@@ -96,6 +96,11 @@ internal static class FileCreationUtils
         return await File.ReadAllTextAsync(path)!;
     }
 
+    public static async Task CreateUpdatRConfigAsync(string path, string json)
+    {
+        await File.WriteAllTextAsync(path, json);
+    }
+
     public static void CreateNuGetConfig(string path, bool addNuGetOrg = false)
     {
         var nugetContent = GetResource("UpdatR.IntegrationTests.Resources.Templates.nuget.config");

--- a/tests/UpdatR.IntegrationTests/UpdaterTests.Given_UpdatRRcFileAndCliExcludePackage_When_Update_Then_ExcludesAreMerged.verified.txt
+++ b/tests/UpdatR.IntegrationTests/UpdaterTests.Given_UpdatRRcFileAndCliExcludePackage_When_Update_Then_ExcludesAreMerged.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  [],
+  <?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Dummy.Tool" Version="0.0.1" />
+    <PackageReference Include="Has.Previews" Version="0.0.1" />
+  </ItemGroup>
+</Project>,
+  <?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Dummy.Tool" Version="0.0.1" />
+    <PackageReference Include="Has.Previews" Version="0.0.1" />
+  </ItemGroup>
+</Project>
+]

--- a/tests/UpdatR.IntegrationTests/UpdaterTests.Given_UpdatRRcFile_When_ExcludesPackage_Then_DoNotUpdate.verified.txt
+++ b/tests/UpdatR.IntegrationTests/UpdaterTests.Given_UpdatRRcFile_When_ExcludesPackage_Then_DoNotUpdate.verified.txt
@@ -1,0 +1,40 @@
+﻿[
+  [
+    {
+      PackageId: Has.Previews,
+      Updates: [
+        {
+          Item1: 0.0.1,
+          Item2: 0.0.2,
+          Item3: src\Dummy.App.csproj
+        }
+      ]
+    }
+  ],
+  <?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Dummy.Tool" Version="0.0.1" />
+    <PackageReference Include="Has.Previews" Version="0.0.1" />
+  </ItemGroup>
+</Project>,
+  <?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Dummy.Tool" Version="0.0.1" />
+    <PackageReference Include="Has.Previews" Version="0.0.2" />
+  </ItemGroup>
+</Project>
+]

--- a/tests/UpdatR.IntegrationTests/UpdaterTests.cs
+++ b/tests/UpdatR.IntegrationTests/UpdaterTests.cs
@@ -463,6 +463,95 @@ public class UpdaterTests
         }
     }
 
+    [Fact]
+    public async Task Given_UpdatRRcFile_When_ExcludesPackage_Then_DoNotUpdate()
+    {
+        // Arrange
+        var temp = Path.Combine(
+            Paths.Temporary.Root,
+            nameof(Given_UpdatRRcFile_When_ExcludesPackage_Then_DoNotUpdate)
+        );
+        var tempCsproj = Path.Combine(temp, "src", "Dummy.App.csproj");
+        var tempNuget = Path.Combine(temp, "nuget.config");
+
+        Directory.CreateDirectory(temp);
+        Directory.CreateDirectory(Path.GetDirectoryName(tempCsproj)!);
+
+        var csprojOriginal = await CreateTempCsprojAsync(
+            tempCsproj,
+            new KeyValuePair<string, string>("Dummy.Tool", "0.0.1"),
+            new KeyValuePair<string, string>("Has.Previews", "0.0.1")
+        );
+
+        CreateNuGetConfig(tempNuget);
+
+        await CreateUpdatRConfigAsync(
+            Path.Combine(temp, ".updatrrc"),
+            """{ "excludePackages": ["Dummy.*"] }"""
+        );
+
+        var update = new Updater();
+
+        // Act
+        var summary = await update.UpdateAsync(temp);
+
+        // Assert
+        await Verify(GetVerifyObjects());
+
+        async IAsyncEnumerable<object> GetVerifyObjects()
+        {
+            yield return summary.UpdatedPackages;
+
+            yield return csprojOriginal;
+            yield return await File.ReadAllTextAsync(tempCsproj);
+        }
+    }
+
+    [Fact]
+    public async Task Given_UpdatRRcFileAndCliExcludePackage_When_Update_Then_ExcludesAreMerged()
+    {
+        // Arrange
+        var temp = Path.Combine(
+            Paths.Temporary.Root,
+            nameof(Given_UpdatRRcFileAndCliExcludePackage_When_Update_Then_ExcludesAreMerged)
+        );
+        var tempCsproj = Path.Combine(temp, "src", "Dummy.App.csproj");
+        var tempNuget = Path.Combine(temp, "nuget.config");
+
+        Directory.CreateDirectory(temp);
+        Directory.CreateDirectory(Path.GetDirectoryName(tempCsproj)!);
+
+        var csprojOriginal = await CreateTempCsprojAsync(
+            tempCsproj,
+            new KeyValuePair<string, string>("Dummy.Tool", "0.0.1"),
+            new KeyValuePair<string, string>("Has.Previews", "0.0.1")
+        );
+
+        CreateNuGetConfig(tempNuget);
+
+        // Config excludes Dummy.*, CLI excludes Has.*: both should end up excluded (union).
+        await CreateUpdatRConfigAsync(
+            Path.Combine(temp, ".updatrrc"),
+            """{ "excludePackages": ["Dummy.*"] }"""
+        );
+
+        var update = new Updater();
+
+        // Act
+        var summary = await update.UpdateAsync(temp, ["Has.*"]);
+
+        // Assert
+        await Verify(GetVerifyObjects());
+
+        async IAsyncEnumerable<object> GetVerifyObjects()
+        {
+            yield return summary.UpdatedPackages;
+
+            yield return csprojOriginal;
+            yield return await File.ReadAllTextAsync(tempCsproj);
+        }
+    }
+
     [Theory]
     [InlineData("Dummy.*", "Microsoft.*")]
     [InlineData("Dummy.*", "Dummy.Tool")]

--- a/tests/UpdatR.UnitTests/Internals/UpdatRConfigTests.cs
+++ b/tests/UpdatR.UnitTests/Internals/UpdatRConfigTests.cs
@@ -1,0 +1,130 @@
+﻿using UpdatR.Internals;
+
+namespace UpdatR.UnitTests;
+
+public class UpdatRConfigTests
+{
+    [Fact]
+    public void LoadReturnsNullWhenNoConfigFileExists()
+    {
+        // Arrange
+        var temp = CreateTempDirectory();
+
+        // Act
+        var config = UpdatRConfig.Load(temp);
+
+        // Assert
+        Assert.Null(config);
+    }
+
+    [Fact]
+    public void LoadReturnsConfigWhenFileIsNextToDirectoryPath()
+    {
+        // Arrange
+        var temp = CreateTempDirectory();
+
+        File.WriteAllText(
+            Path.Combine(temp, UpdatRConfig.FileName),
+            """
+            {
+              "excludePackages": ["Foo.*"],
+              "allowedLicenses": ["MIT", "Apache-2.0"]
+            }
+            """
+        );
+
+        // Act
+        var config = UpdatRConfig.Load(temp);
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.Equal(["Foo.*"], config.ExcludePackages ?? []);
+        Assert.Equal(["MIT", "Apache-2.0"], config.AllowedLicenses ?? []);
+    }
+
+    [Fact]
+    public void LoadReturnsConfigWhenFileIsNextToFilePath()
+    {
+        // Arrange
+        var temp = CreateTempDirectory();
+        var csproj = Path.Combine(temp, "Project.csproj");
+
+        File.WriteAllText(csproj, "<Project />");
+        File.WriteAllText(
+            Path.Combine(temp, UpdatRConfig.FileName),
+            """{ "excludePackages": ["Foo.*"] }"""
+        );
+
+        // Act
+        var config = UpdatRConfig.Load(csproj);
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.Equal(["Foo.*"], config.ExcludePackages ?? []);
+    }
+
+    [Fact]
+    public void LoadFallsBackToCurrentDirectoryWhenNoConfigNextToPath()
+    {
+        // Arrange
+        var temp = CreateTempDirectory();
+        var targetDir = Path.Combine(temp, "target");
+
+        Directory.CreateDirectory(targetDir);
+
+        File.WriteAllText(
+            Path.Combine(temp, UpdatRConfig.FileName),
+            """{ "allowedLicenses": ["MIT"] }"""
+        );
+
+        var originalCurrentDirectory = Directory.GetCurrentDirectory();
+
+        try
+        {
+            Directory.SetCurrentDirectory(temp);
+
+            // Act
+            var config = UpdatRConfig.Load(targetDir);
+
+            // Assert
+            Assert.NotNull(config);
+            Assert.Equal(["MIT"], config.AllowedLicenses ?? []);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalCurrentDirectory);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(MergeData))]
+    public void Merge(string[]? fromArgs, string[]? fromConfig, string[]? expected)
+    {
+        // Act
+        var result = UpdatRConfig.Merge(fromArgs, fromConfig);
+
+        // Assert
+        Assert.Equal(expected ?? [], result ?? []);
+    }
+
+    public static TheoryData<string[]?, string[]?, string[]?> MergeData =>
+        new()
+        {
+            { null, null, null },
+            { [], null, null },
+            { null, ["Foo.*"], ["Foo.*"] },
+            { ["Foo.*"], null, ["Foo.*"] },
+            { ["Foo.*"], [], ["Foo.*"] },
+            { ["Foo.*"], ["Bar.*"], ["Foo.*", "Bar.*"] },
+            { ["Foo.*"], ["foo.*", "Bar.*"], ["Foo.*", "Bar.*"] },
+        };
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "UpdatR-tests", Guid.NewGuid().ToString("N"));
+
+        Directory.CreateDirectory(path);
+
+        return path;
+    }
+}


### PR DESCRIPTION
Adds support for a .updatrrc JSON config file with ExcludePackages and AllowedLicenses, as a starting point per issue #191. The file is looked up next to the target path (or its containing directory if it's a file), falling back to the current working directory. Values from the config file are merged (union) with the corresponding --exclude-package / --allowed-licenses CLI options / Updater.UpdateAsync parameters.

Closing #191 