### PR TITLE
fix: Missing PackageId when PackageReference uses Update attribute

### DIFF
--- a/src/UpdatR/Domain/Csproj.cs
+++ b/src/UpdatR/Domain/Csproj.cs
@@ -92,7 +92,9 @@ internal sealed partial class Csproj
 
         foreach (var packageReference in packageReferences)
         {
-            var packageId = packageReference.GetAttribute("Include");
+            var packageId = packageReference.HasAttribute("Include")
+                ? packageReference.GetAttribute("Include")
+                : packageReference.GetAttribute("Update");
 
             if (!packageReference.HasAttribute("Version"))
             {
@@ -347,7 +349,12 @@ internal sealed partial class Csproj
         _doc.SelectNodes("/Project/ItemGroup/PackageReference")!
             .OfType<XmlElement>()
             .Select(x =>
-                (PackageId: x!.GetAttribute("Include"), Version: x!.GetAttribute("Version"))
+                (
+                    PackageId: x!.HasAttribute("Include")
+                        ? x!.GetAttribute("Include")
+                        : x!.GetAttribute("Update"),
+                    Version: x!.GetAttribute("Version")
+                )
             )
             .Where(x =>
                 !string.IsNullOrWhiteSpace(x.PackageId) && NuGetVersion.TryParse(x.Version, out _)

--- a/src/UpdatR/Domain/PropsFile.cs
+++ b/src/UpdatR/Domain/PropsFile.cs
@@ -98,7 +98,9 @@ internal sealed partial class PropsFile
 
         foreach (var item in items)
         {
-            var packageId = item.GetAttribute("Include");
+            var packageId = item.HasAttribute("Include")
+                ? item.GetAttribute("Include")
+                : item.GetAttribute("Update");
 
             if (!item.HasAttribute("Version"))
             {
@@ -347,7 +349,12 @@ internal sealed partial class PropsFile
         _doc.SelectNodes("/Project/ItemGroup/PackageReference|/Project/ItemGroup/PackageVersion")!
             .OfType<XmlElement>()
             .Select(x =>
-                (PackageId: x!.GetAttribute("Include"), Version: x!.GetAttribute("Version"))
+                (
+                    PackageId: x!.HasAttribute("Include")
+                        ? x!.GetAttribute("Include")
+                        : x!.GetAttribute("Update"),
+                    Version: x!.GetAttribute("Version")
+                )
             )
             .Where(x =>
                 !string.IsNullOrWhiteSpace(x.PackageId) && NuGetVersion.TryParse(x.Version, out _)

--- a/tests/UpdatR.UnitTests/Domain/CsprojTests.cs
+++ b/tests/UpdatR.UnitTests/Domain/CsprojTests.cs
@@ -100,6 +100,67 @@ public class CsprojTests : IDisposable
     }
 
     [Fact]
+    public void UpdatePackagesUpdatesPackageReferenceUsingUpdateAttribute()
+    {
+        // Arrange - PackageReference using Update (instead of Include) only overrides the
+        // version of a package already referenced elsewhere, e.g. via Directory.Build.props.
+        File.WriteAllText(
+            _csprojPath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Update="Some.Package" Version="1.0.0" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        var csproj = Csproj.Create(_csprojPath);
+        var logger = new FakeLogger();
+
+        var package = new NuGetPackage(
+            "Some.Package",
+            [
+                new UpdatR.Internals.PackageMetadata(
+                    NuGetVersion.Parse("1.0.0"),
+                    [NuGetFramework.Parse("net10.0")],
+                    null,
+                    null
+                ),
+                new UpdatR.Internals.PackageMetadata(
+                    NuGetVersion.Parse("2.0.0"),
+                    [NuGetFramework.Parse("net10.0")],
+                    null,
+                    null
+                ),
+            ]
+        );
+
+        // Act
+        var result = csproj.UpdatePackages(
+            new Dictionary<string, NuGetPackage?> { ["Some.Package"] = package },
+            dryRun: false,
+            usePrerelease: false,
+            logger: logger
+        );
+
+        // Assert
+        Assert.NotNull(result);
+
+        var updated = Assert.Single(result.UpdatedPackages);
+
+        Assert.Equal("Some.Package", updated.PackageId);
+        Assert.Equal(NuGetVersion.Parse("1.0.0"), updated.From);
+        Assert.Equal(NuGetVersion.Parse("2.0.0"), updated.To);
+
+        Assert.Contains("""Version="2.0.0" """.Trim(), File.ReadAllText(_csprojPath));
+        Assert.DoesNotContain(logger.Logs, x => x.Level == LogLevel.Warning);
+    }
+
+    [Fact]
     public void UpdatePackagesLogsLicenseMismatchForInstalledVersion()
     {
         // Arrange

--- a/tests/UpdatR.UnitTests/Domain/PropsFileTests.cs
+++ b/tests/UpdatR.UnitTests/Domain/PropsFileTests.cs
@@ -60,6 +60,45 @@ public class PropsFileTests : IDisposable
     }
 
     [Fact]
+    public void UpdatePackagesUpdatesPackageReferenceUsingUpdateAttribute()
+    {
+        // Arrange - PackageReference using Update (instead of Include) only overrides the
+        // version of a package already referenced elsewhere, e.g. via Directory.Build.props.
+        File.WriteAllText(
+            _propsPath,
+            """
+            <Project>
+              <ItemGroup>
+                <PackageReference Update="Some.Package" Version="1.0.0" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        var propsFile = PropsFile.Create(_propsPath, [NuGetFramework.Parse("net10.0")]);
+        var packages = CreatePackages("Some.Package", "1.0.0", "2.0.0");
+        var logger = new FakeLogger();
+
+        // Act
+        var result = propsFile.UpdatePackages(
+            packages,
+            dryRun: false,
+            usePrerelease: false,
+            logger: logger
+        );
+
+        // Assert
+        var updated = Assert.Single(result!.UpdatedPackages);
+
+        Assert.Equal("Some.Package", updated.PackageId);
+        Assert.Equal(NuGetVersion.Parse("1.0.0"), updated.From);
+        Assert.Equal(NuGetVersion.Parse("2.0.0"), updated.To);
+
+        Assert.Contains("""Version="2.0.0" """.Trim(), File.ReadAllText(_propsPath));
+        Assert.DoesNotContain(logger.Logs, x => x.Level == LogLevel.Warning);
+    }
+
+    [Fact]
     public void UpdatePackagesUpdatesPackageVersionForCentralPackageManagement()
     {
         // Arrange
@@ -487,6 +526,31 @@ public class PropsFileTests : IDisposable
         // Assert
         Assert.Equal(NuGetVersion.Parse("1.0.0"), packages["Package.One"]);
         Assert.Equal(NuGetVersion.Parse("2.0.0"), packages["Package.Two"]);
+    }
+
+    [Fact]
+    public void PackagesReturnsPackageReferenceUsingUpdateAttribute()
+    {
+        // Arrange - PackageReference using Update (instead of Include) only overrides the
+        // version of a package already referenced elsewhere, e.g. via Directory.Build.props.
+        File.WriteAllText(
+            _propsPath,
+            """
+            <Project>
+              <ItemGroup>
+                <PackageReference Update="Package.One" Version="1.0.0" />
+              </ItemGroup>
+            </Project>
+            """
+        );
+
+        var propsFile = PropsFile.Create(_propsPath);
+
+        // Act
+        var packages = propsFile.Packages;
+
+        // Assert
+        Assert.Equal(NuGetVersion.Parse("1.0.0"), packages["Package.One"]);
     }
 
     private static Dictionary<string, NuGetPackage?> CreatePackages(


### PR DESCRIPTION
PackageReference/PackageVersion items that only set the Update attribute (e.g. <PackageReference Update="X" Version="Y" />, used to override the version of a package referenced elsewhere such as via Directory.Build.props) were read via the Include attribute only. Since Include was empty, the package id resolved to an empty string, causing a bogus 'Could not find .' warning and the package being treated as unknown/never updated.

Csproj and PropsFile now fall back to the Update attribute when Include is not present, both when updating packages and when building the Packages dictionary.