### PR TITLE
feat: Add SourceLink support to packages

### DIFF
--- a/src/Build/docs/release-notes.txt
+++ b/src/Build/docs/release-notes.txt
@@ -2,3 +2,4 @@
 - breaking: To support .props and .targets files, UpdatR now requires the .NET SDK to be installed on the machine.
 - Add `--allowed-licenses` option to filter package updates by license expression (case-insensitive substring match). Packages without license information are always allowed. The currently installed version is also checked and reported as a mismatch if applicable.
 - breaking: `Updater.UpdateAsync` has a new optional `allowedLicenses` parameter and `Summary` has a new `LicenseMismatchPackages` property.
+- Add SourceLink support to the `UpdatR` and `dotnet-updatr` packages, enabling source debugging and repository metadata (commit, branch, URL) in the published NuGet packages.

--- a/src/Build/nuget.props
+++ b/src/Build/nuget.props
@@ -7,9 +7,18 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/docs/release-notes.txt"))</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/OskarKlintrot/UpdatR</RepositoryUrl>
     <PackageOutputPath>$(SolutionDir)/Artifacts</PackageOutputPath>
     <!--<GenerateDocumentationFile>true</GenerateDocumentationFile>-->
+    <!--
+      Source Link. RepositoryUrl/RepositoryType/RepositoryCommit are intentionally left unset here
+      so Microsoft.SourceLink.GitHub can populate them from the local git repository (origin remote
+      and current commit) - hardcoding RepositoryUrl would prevent RepositoryCommit from being set,
+      since SourceLink only stamps the commit when RepositoryUrl still matches what it detected.
+    -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
+    <EnableSourceControlManagerQueries>true</EnableSourceControlManagerQueries>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +32,21 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <!--
+      Microsoft.SourceLink.Common and Microsoft.Build.Tasks.Git only apply their real build logic
+      when directly referenced - when pulled in only transitively (e.g. via Microsoft.SourceLink.GitHub
+      above) NuGet resolves their "build" assets to an empty buildTransitive/_._ placeholder, so the
+      git commit/branch detection they provide never actually runs. Referencing them directly here
+      activates that detection so RepositoryCommit/SourceLink URLs get populated correctly.
+    -->
+    <PackageReference Include="Microsoft.SourceLink.Common" Version="10.0.400">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Tasks.Git" Version="10.0.400">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Closes #60

Enables SourceLink for the UpdatR and dotnet-updatr NuGet packages so consumers can step into package source while debugging.

- Add PublishRepositoryUrl, EmbedUntrackedSources and embedded DebugType to src/Build/nuget.props.
- Add direct PackageReference to Microsoft.SourceLink.Common and Microsoft.Build.Tasks.Git alongside Microsoft.SourceLink.GitHub - without direct references these packages resolve to an empty uildTransitive/_._ placeholder when only pulled in transitively, so git commit/branch detection never runs.
- Verified the packed .nuspec now includes <repository type="git" url="..." branch="..." commit="..." /> and that an embedded SourceLink JSON mapping to raw.githubusercontent.com is generated for both packages.